### PR TITLE
Allow passing DLL paths (fix #1)

### DIFF
--- a/TTD/TTD.cpp
+++ b/TTD/TTD.cpp
@@ -100,7 +100,7 @@ namespace TTD {
 		return this->cursor->ICursor->GetModuleList(cursor);
 	}
 
-	ReplayEngine::ReplayEngine() {
+	ReplayEngine::ReplayEngine(const wchar_t* ttdReplayPath, const wchar_t* ttdReplayCpuPath) {
 		HINSTANCE hinstLib;
 		PROC_Initiate InitiateReplayEngineHandshake;
 		PROC_Create CreateReplayEngineWithHandshake;
@@ -109,7 +109,12 @@ namespace TTD {
 		SHA256_CTX ctx;
 		BYTE sha[32];
 
-		hinstLib = LoadLibrary(TEXT("TTDReplay.dll"));
+		hinstLib = LoadLibraryW(ttdReplayCpuPath);
+		if (hinstLib == NULL) {
+			throw std::exception("Unable to find TTDReplayCPU.dll");
+		}
+
+		hinstLib = LoadLibraryW(ttdReplayPath);
 		if (hinstLib == NULL) {
 			throw std::exception("Unable to find TTDReplay.dll");
 		}

--- a/TTD/TTD.hpp
+++ b/TTD/TTD.hpp
@@ -494,7 +494,7 @@ namespace TTD {
 		TTD_Replay_ReplayEngine* engine;
 
 	public:
-		ReplayEngine();
+		ReplayEngine(const wchar_t* ttdReplayPath=L"TTDReplay.dll", const wchar_t* ttdReplayCpuPath=L"TTDReplayCPU.dll");
 
 		/**** Wrapping around the vftable ****/
 		bool Initialize(const wchar_t* trace_filename);


### PR DESCRIPTION
This PR adds two parameters to `ReplayEngine::ReplayEngine()`, which represent the path to the `TTDReplay.dll` and `TTDReplayCPU.dll` libraries. This way, we can load the libraries even if they are not in the same directory as the executable using the bindings.

This PR also explicitly loads `TTDReplayCPU.dll` while setting up the engine. Even if we don't directly use it, `TTDReplay.dll` requires it to be loaded to function.